### PR TITLE
Fix the maven publish workflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,13 @@
 			</snapshots>
 		</repository>
 	</repositories>
+	
+	<distributionManagement>
+		<snapshotRepository>
+			<id>nexus-sonatype</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
 
 	<pluginRepositories>
 		<pluginRepository>


### PR DESCRIPTION
Cherry-pick of commit 6caa53a — adds missing distribution management to fix the build and publish workflow.