### PR TITLE
Fix Sonatype publish workflow

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-publish-package:

--- a/pom.xml
+++ b/pom.xml
@@ -274,11 +274,11 @@
 	<distributionManagement>
 		<snapshotRepository>
 			<id>nexus-sonatype</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
 		<repository>
 			<id>nexus-sonatype</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+			<url>https://central.sonatype.com</url>
 		</repository>
 	</distributionManagement>
 


### PR DESCRIPTION
- Update distributionManagement URLs in pom.xml from deprecated oss.sonatype.org to central.sonatype.com
- Fix build_publish.yaml trigger branch from master to main so SNAPSHOT deploys actually run