### PR TITLE
Add workflow_dispatch trigger to build_publish workflow

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -2,6 +2,7 @@ name: Build and Publish package
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build-publish-package:


### PR DESCRIPTION
## Summary
- Restores `workflow_dispatch` trigger that was removed during the BAH-4541 workflow rewrite
- Allows the build & publish workflow to be triggered manually from the GitHub Actions UI

## Test plan
- [ ] Merge PR into `main`
- [ ] Navigate to Actions → Build and Publish package → verify "Run workflow" button is available
- [ ] Trigger manually and confirm it runs successfully