### PR TITLE
Bump version to 1.1.0-SNAPSHOT

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>bahmni-events</artifactId>
 		<groupId>org.bahmni.module</groupId>
-		<version>1.0.0</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bahmni-events-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.bahmni.module</groupId>
 	<artifactId>bahmni-events</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Bahmni Events</name>
 	<description>Bahmni events module to send business events which can be used by external services</description>


### PR DESCRIPTION
## Summary
- Bumps project version from `1.0.0` to `1.1.0-SNAPSHOT` in root and omod `pom.xml`
- Required for the build_publish workflow to deploy the artifact (it skips non-SNAPSHOT versions)

## Test plan
- [ ] Merge PR into `main`
- [ ] Trigger the workflow manually via Actions → Build and Publish package → Run workflow
- [ ] Confirm artifact is published to Sonatype