### PR TITLE
Fix Sonatype Central publish — replace nexus-staging-maven-plugin

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -9,11 +9,12 @@ jobs:
     name: Build and Publish package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'temurin'
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/.github/workflows/release_deploy.yml
+++ b/.github/workflows/release_deploy.yml
@@ -9,11 +9,12 @@ jobs:
     name: Build and Release package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'temurin'
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -91,22 +91,12 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>1.5.1</version>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.7.0</version>
 					<extensions>true</extensions>
-					<executions>
-						<execution>
-							<id>default-deploy</id>
-							<phase>deploy</phase>
-							<goals>
-								<goal>deploy</goal>
-							</goals>
-						</execution>
-					</executions>
 					<configuration>
-						<serverId>nexus-sonatype</serverId>
-						<nexusUrl>https://oss.sonatype.org</nexusUrl>
+						<publishingServerId>nexus-sonatype</publishingServerId>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
## Summary
- Replaces `nexus-staging-maven-plugin` v1.5.1 (old OSSRH plugin, incompatible with the new Central Portal) with `central-publishing-maven-plugin` v0.7.0 — matching the pattern already adopted by 19 other Bahmni repos
- Updates deprecated `actions/checkout@v2` → `@v4` and `actions/setup-java@v1` → `@v4` in both workflows

## Root cause
The `release_deploy.yml` run for the `1.0.0` tag failed because `nexus-staging-maven-plugin` cannot communicate with `central.sonatype.com` (new Central Portal API). The `distributionManagement` URLs were already correct.

## Note
Secrets (`NEXUS_USERNAME`, `NEXUS_PASSWORD`, `BAHMNI_INFRA_GPG_KEY`, `BAHMNI_INFRA_GPG_PASSPHRASE`) still need to be added to the repo settings before the release workflow can succeed.

## Test plan
- [ ] Merge PR into `main`
- [ ] Add required secrets to repo Settings → Secrets → Actions
- [ ] Re-push the `1.0.0` tag to re-trigger `release_deploy.yml`
- [ ] Confirm artifact published at https://central.sonatype.com/artifact/org.bahmni.module/bahmni-events

🤖 Generated with [Claude Code](https://claude.com/claude-code)