### PR TITLE
BAH-5023 | Add SECURITY.md (vulnerability disclosure policy)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Please **do not** report security vulnerabilities through public GitHub issues or pull requests.
+
+Report them privately to **security@bahmni.org**.
+
+The full reporting, discussion, and disclosure process is documented here:
+https://bahmni.atlassian.net/wiki/spaces/BAH/pages/884277257/Security+-+Reporting+and+Discussion


### PR DESCRIPTION
## Summary

Adds `SECURITY.md` at the repo root. Points security researchers to Bahmni's private vulnerability disclosure process — report to **security@bahmni.org** rather than via public issues/PRs — and links to the full process on the Bahmni wiki.

Part of the rollout tracked in [BAH-5023](https://bahmni.atlassian.net/browse/BAH-5023), a follow-up to [BAH-4802](https://bahmni.atlassian.net/browse/BAH-4802) (same template, applied to repos outside that ticket's original 19-repo scope). Thin by design: the wiki remains the canonical Bahmni security documentation; this file is an on-GitHub signpost to it.

## Why

GitHub renders `SECURITY.md` as the repo's "Security policy" (Security tab) and surfaces it when someone opens an issue, giving researchers clear guidance to disclose privately. Satisfies the `ch_security_policy` check in the Bahmni OSS best-practices audit.

## Test plan

- [ ] `SECURITY.md` visible at repo root
- [ ] Repo "Security" tab shows the policy
- [ ] Links resolve (security@bahmni.org, wiki page)

[BAH-5023]: https://bahmni.atlassian.net/browse/BAH-5023
[BAH-4802]: https://bahmni.atlassian.net/browse/BAH-4802
