### PR TITLE
BAH-5024 | Add Semgrep SAST CI workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,31 @@
+name: Semgrep SAST
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '24 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      # semgrep/semgrep:1.165.0 — pinned by digest; bump manually when needed
+      image: semgrep/semgrep@sha256:bd2ada83c7aa5a60e07d86ee84ba0c12282264781c8d783be5a912549a94394f
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - run: semgrep scan --config auto --sarif --output semgrep.sarif
+        continue-on-error: true
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+        if: always() && hashFiles('semgrep.sarif') != ''
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     branches: [main, master]
-  schedule:
-    - cron: '24 13 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/semgrep.yml`. Runs [Semgrep Community Edition](https://docs.semgrep.dev/deployment/oss-deployment) static analysis on PRs, pushes to main/master, and weekly. Findings upload to the **Security tab** (Code Scanning) via SARIF.

Part of the rollout tracked in [BAH-5024](https://bahmni.atlassian.net/browse/BAH-5024), a follow-up to [BAH-4795](https://bahmni.atlassian.net/browse/BAH-4795) (same hardened template, applied to repos outside that ticket's original 17-repo scope). Template validated on [bahmni-core#330](https://github.com/Bahmni/bahmni-core/pull/330): container image and actions pinned to immutable digests/SHAs, least-privilege checkout (`persist-credentials: false`), SARIF upload guarded by `hashFiles()` so the workflow stays non-blocking if Semgrep crashes before producing the SARIF file.

## What it catches

OWASP-class bugs: SQL injection, path traversal, XSS, command injection, insecure deserialization. ~2,000 community rules cover the auto-detected language set.

## Phase 1 — non-blocking

`continue-on-error: true` is set so existing findings on legacy code do **not** fail PRs. Findings still surface in the Security tab for review. A follow-up PR will remove that flag and add `--baseline-ref` once a baseline is triaged.

## Cost: $0

- Semgrep Community Edition (LGPL-2.1), public registry rules — free for commercial + OSS
- No `SEMGREP_APP_TOKEN`, no Semgrep Cloud account
- GitHub Code Scanning — free for public repos

## Test plan

- [ ] Workflow appears in the Actions tab and runs on this PR
- [ ] Scan completes (success or non-zero exit — both are fine in phase 1)
- [ ] SARIF uploads to the Security tab (Code scanning alerts)
- [ ] Subsequent push to the default branch triggers the workflow
- [ ] Weekly schedule appears under Actions → Semgrep SAST

[BAH-5024]: https://bahmni.atlassian.net/browse/BAH-5024
[BAH-4795]: https://bahmni.atlassian.net/browse/BAH-4795
